### PR TITLE
Pre policy filter

### DIFF
--- a/clients/zenodo_client.py
+++ b/clients/zenodo_client.py
@@ -223,6 +223,8 @@ class Client(APIClient):
             "title": x["metadata"]["title"],
             "doctype": x["metadata"]["resource_type"]["title"],
             "pubyear": x["metadata"]["publication_date"][0:4],
+            # Neutral information to keep reporting happy
+            "journalTitle": None,
         }
         return record
 

--- a/data_pipeline/enricher.py
+++ b/data_pipeline/enricher.py
@@ -21,6 +21,7 @@ from config import logs_dir
 
 dspace_wrapper = DSpaceClientWrapper()
 
+
 class AuthorProcessor:
     """
     This class is designed to process a DataFrame containing research publications and enrich it with information about EPFL affiliations.
@@ -38,6 +39,7 @@ class AuthorProcessor:
     processor = Processor(your_dataframe)
     processor.process().nameparse_authors().orcid_data_reconciliation()
     """
+
     def __init__(self, df):
         self.df = df
 
@@ -245,7 +247,7 @@ class AuthorProcessor:
                 f"Error querying DSpace for author {query} - {e}"
             )
 
-        return None    
+        return None
 
     def api_epfl_reconciliation(self, return_df=False):
         self.df = self.df.copy()  # Create a copy of the DataFrame if necessary
@@ -515,6 +517,7 @@ class AuthorProcessor:
 
         return self.df if return_df else self
 
+
 class PublicationProcessor:
 
     def __init__(self, df):
@@ -541,6 +544,12 @@ class PublicationProcessor:
                 self.df.at[index, 'upw_pdf_urls'] = result.get('pdf_urls')
                 self.df.at[index, "upw_valid_pdf"] = result.get("valid_pdf")
             else:
+                self.df.at[index, "upw_is_oa"] = None
+                self.df.at[index, 'upw_oa_status'] = None
+                self.df.at[index, "upw_license"] = None
+                self.df.at[index, "upw_version"] = None
+                self.df.at[index, 'upw_pdf_urls'] = None
+                self.df.at[index, "upw_valid_pdf"] = None
                 self.logger.warning(f"No unpaywall data returned for DOI {self.df.at[index, 'doi']}.")
 
         return self.df if return_df else self

--- a/data_pipeline/harvester.py
+++ b/data_pipeline/harvester.py
@@ -265,14 +265,14 @@ class ZenodoHarvester(Harvester):
 
         total = ZenodoClient.count_results(q=updated_query)
         self.logger.info(f"- Nombre d'objets trouvées dans Zenodo: {total}")
-        if total == "0":  # Zenodo API returns 0 as string
+        if total == 0:
             self.logger.warning("No object found. Returning an empty DataFrame.")
             return pd.DataFrame()
         size = 50
         recs = []
         for i in range(0, 1 + int(total) // size):
             self.logger.info(
-                f"Harvest objects {i*size+1} to {min((i+1)*size, total)} out of a total of {total} objects"
+                f"Harvest objects {i*size+1} to {min((i+1)*size, total)} out of {total}"
             )
             h_recs = ZenodoClient.fetch_records(
                 format=self.format, q=updated_query, size=size, page=i + 1
@@ -288,8 +288,6 @@ class ZenodoHarvester(Harvester):
             .query(f'first_creation > "{self.policy_threshold}"')
             .reset_index(drop=True)
         )
-
-        # TODO check the oldest version of each record, filter out if older than policy_threshold
 
         return df
 

--- a/data_pipeline/harvester.py
+++ b/data_pipeline/harvester.py
@@ -2,6 +2,7 @@
 
 import abc
 import os
+import time
 
 import pandas as pd
 from data_pipeline.enricher import AuthorProcessor
@@ -134,12 +135,14 @@ class WosHarvester(Harvester):
         author_processor = AuthorProcessor(df)
 
         df = df[
-            df["affiliation_controlled"].isna() |  
-            df["affiliation_controlled"].astype(str).str.strip().eq("") | 
-            df["affiliation_controlled"].astype(str).apply(lambda x: author_processor.process_scopus(x, check_all=True))
+            df["affiliation_controlled"].isna()
+            | df["affiliation_controlled"].astype(str).str.strip().eq("")
+            | df["affiliation_controlled"]
+            .astype(str)
+            .apply(lambda x: author_processor.process_scopus(x, check_all=True))
         ]
 
-        return df 
+        return df
 
 
 class ScopusHarvester(Harvester):
@@ -171,7 +174,7 @@ class ScopusHarvester(Harvester):
         updated_query = f'({self.query}) AND (ORIG-LOAD-DATE AFT {self.start_date.replace("-","")}) AND (ORIG-LOAD-DATE BEF {self.end_date.replace("-","")})'
         total = ScopusClient.count_results(query=updated_query)
         self.logger.info(f"- Nombre de publications trouvées dans Scopus: {total}")
-        
+
         if total == "0":  # scopus API returns 0 as string
             self.logger.debug("No publications found. Returning an empty DataFrame.")
             return pd.DataFrame()
@@ -179,7 +182,7 @@ class ScopusHarvester(Harvester):
         total = int(total)  # Convert total to integer for calculations
         count = 50
         recs = []
-        
+
         # Special case: Handle single result
         if total == 1:
             self.logger.info("Only one publication found. Fetching the single record.")
@@ -211,6 +214,9 @@ class ZenodoHarvester(Harvester):
     Zenodo Harvester.
     """
 
+    policy_threshold = pd.to_datetime("2023-03-01")
+    # older_recid = "7712815"
+
     def __init__(
         self, start_date: str, end_date: str, query: str, format: str = "ifs3"
     ):
@@ -218,10 +224,10 @@ class ZenodoHarvester(Harvester):
 
     def fetch_and_parse_publications(self) -> pd.DataFrame:
         """
-        Returns a pandas DataFrame containing objeczs harvested from Zenodo.
+        Returns a pandas DataFrame containing objects harvested from Zenodo.
 
         Using the "ifs3" default format, the DataFrame includes the following:
-        - `source`: source database of the objecz's metadata (value "zenodo")
+        - `source`: source database of the object's metadata (value "zenodo")
         - `internal_id`: internal ID of the object in the source DB (xxxxx).
         - `title`: The title of the object.
         - `doi`: Digital Object Identifier of the object.
@@ -247,6 +253,7 @@ class ZenodoHarvester(Harvester):
             "ifs3_collection",
             "ifs3_collection_id",
             "authors",
+            "first_creation",
         )
         empty_data = {}
         for c in columns:
@@ -258,29 +265,31 @@ class ZenodoHarvester(Harvester):
 
         total = ZenodoClient.count_results(q=updated_query)
         self.logger.info(f"- Nombre d'objets trouvées dans Zenodo: {total}")
-        if total == 0:  # Zenodo API returns 0 as string
+        if total == "0":  # Zenodo API returns 0 as string
             self.logger.warning("No object found. Returning an empty DataFrame.")
             return pd.DataFrame()
         size = 50
         recs = []
-        # print(total)
-        # print(range(0, 1 + int(total) // size))
         for i in range(0, 1 + int(total) // size):
             self.logger.info(
-                f"Harvest objects {i*size*(int(total)//size)+1} to {i*size*(int(total)//size)} out of a total of {total} objects"
+                f"Harvest objects {i*size+1} to {min((i+1)*size, total)} out of a total of {total} objects"
             )
             h_recs = ZenodoClient.fetch_records(
                 format=self.format, q=updated_query, size=size, page=i + 1
             )
             if h_recs is not None:
                 recs.extend(h_recs)
+            time.sleep(30)
         # Keep only valid ifs3 doctypes, filter out unknown_doctype
         # print(recs)
         df = (
             pd.DataFrame(recs)
             .query('ifs3_collection != "unknown"')
+            .query(f'first_creation > "{self.policy_threshold}"')
             .reset_index(drop=True)
         )
+
+        # TODO check the oldest version of each record, filter out if older than policy_threshold
 
         return df
 
@@ -330,7 +339,9 @@ class OpenAlexHarvester(Harvester):
         recs = []
 
         # Fetch records in pages of `count` items each
-        for page in range(1, (total // count) + 2):  # Adjusted to +2 to handle last page
+        for page in range(
+            1, (total // count) + 2
+        ):  # Adjusted to +2 to handle last page
             self.logger.info(f"Harvesting page {page} out of {total // count + 1}")
 
             try:

--- a/data_pipeline/loader.py
+++ b/data_pipeline/loader.py
@@ -18,6 +18,8 @@ pdf_dir = project_root / "data" / "pdfs"
 
 
 dspace_wrapper = DSpaceClientWrapper()
+
+
 class Loader:
     """Load items into DSpace using workflow."""
 
@@ -908,6 +910,7 @@ class Loader:
                     and author["epfl_api_mainunit_name"] != ""
                 ]
                 unique_units = {unit["acro"]: unit for unit in units}.values()
+                logger.info(f"Found units: {unique_units}")
 
                 if unique_units:
                     self._patch_additional_metadata(
@@ -946,6 +949,9 @@ class Loader:
                             f"Successfully created workflow item with ID: {workflow_id}"
                         )
                         df_items_imported.at[index, "workflow_id"] = workflow_id
+                    else:
+                        logger.error(f"Unable to create workflow item for workspace item {workspace_id}")
+                        df_items_imported.at[index, "workflow_id"] = None
                 else:
                     logger.warning(
                         f"No matching units found for row ID: {row['row_id']}."

--- a/data_pipeline/reporting.py
+++ b/data_pipeline/reporting.py
@@ -188,7 +188,7 @@ class GenerateReports:
             "OA Publications": self.open_access_publications(),
             "OA with PDF": self.open_access_with_pdf(),
             "Imported in Workspace": self.imported_publications_workspace(),
-            "Imported in Workflow": self.imported_publications_workflow(),
+            #"Imported in Workflow": self.imported_publications_workflow(),
             "Imported by Journal": self.imported_publications_by_journal(),
             "Detected EPFL Authors": self.epfl_affiliated_publications(),
             "Matched EPFL Authors": self.epfl_reconciled_authors(),


### PR DESCRIPTION
Avec ces quelques modifications, le client Zenodo ne récolte que les objets dont la première version a été créée depuis la mise en place de la curation de la communauté EPFL => garantis comme passés par la curation.
Le processus ajoute quelques colonnes neutres dans les Dataframes (infos Unpaywall, journalTitle) => le reporting ne plante pas.
Pour terminer, plus de tentative d'envoi de mail s'il n'y a pas de variable d'environnement SMTP_SERVER => on peut développer sans être obligé de savoir quel genre d'autorisation il faut pour ça.

